### PR TITLE
access getCurrentPosition via navigator.geolocation instead of navigator

### DIFF
--- a/source/scripts/content/gps.js
+++ b/source/scripts/content/gps.js
@@ -40,7 +40,7 @@ function hookGeo() {
   function waitWatchPosition() {
     if ((typeof hookedObj.fakeGeo !== 'undefined')) {
       if (hookedObj.fakeGeo === true) {
-        navigator.getCurrentPosition(hookedObj.tmp2_successCallback, hookedObj.tmp2_errorCallback, hookedObj.tmp2_options);
+        navigator.geolocation.getCurrentPosition(hookedObj.tmp2_successCallback, hookedObj.tmp2_errorCallback, hookedObj.tmp2_options);
         return Math.floor(Math.random() * 10000); // random id
       } else {
         hookedObj.watchPosition(hookedObj.tmp2_successCallback, hookedObj.tmp2_errorCallback, hookedObj.tmp2_options);


### PR DESCRIPTION
Current implementation of Geolocation API leads to error when trying to use `watchPosition` 

Example: https://codesandbox.io/s/heuristic-orla-qkoxe5?file=/index.html

Screenshot:
![express-vpn-geo (2)](https://user-images.githubusercontent.com/24412567/184442139-71df2c9a-9d35-473c-bca2-9dfb2552961c.png)

