### PR TITLE
Fix: Invalid SVG Blob Formatting

### DIFF
--- a/source/scripts/content/gps.js
+++ b/source/scripts/content/gps.js
@@ -87,10 +87,6 @@ function hookGeo(eventName) {
 				const mimeTypeIndex = injectableMimeTypes.findIndex(mimeType => mimeType.mime.toLowerCase() === typeEl.type.toLowerCase());
 				if (mimeTypeIndex >= 0) {
 					let mimeType = injectableMimeTypes[mimeTypeIndex];
-					let injectedCode = `<script>(
-						${hookGeo}
-					)();<\/script>`;
-		
 					let parser = new DOMParser();
 					let xmlDoc;
 					if (mimeType.useXMLparser === true) {
@@ -100,7 +96,26 @@ function hookGeo(eventName) {
 					}
 
 					if (xmlDoc.getElementsByTagName("parsererror").length === 0) { // if no errors were found while parsing...
-						xmlDoc.documentElement.insertAdjacentHTML('afterbegin', injectedCode);
+						if (typeEl.type === "image/svg+xml") {
+						  const scriptElem = xmlDoc.createElementNS(
+						    "http://www.w3.org/2000/svg",
+						    "script",
+						  );
+						  scriptElem.setAttributeNS(null, "type", "application/ecmascript");
+						  scriptElem.innerHTML = `(${hookGeo})();`;
+						  xmlDoc.documentElement.insertBefore(
+						    scriptElem,
+						    xmlDoc.documentElement.firstChild,
+						  );
+						} else {
+						  const injectedCode = `<script>(
+											    	${hookGeo}
+											    )();<\/script>`;
+						  xmlDoc.documentElement.insertAdjacentHTML(
+						    "afterbegin",
+						    injectedCode,
+						  );
+						}
 		
 						if (mimeType.useXMLparser === true) {
 							args[0] = [new XMLSerializer().serializeToString(xmlDoc)];


### PR DESCRIPTION
## Intent

The extension is currently corrupting SVG type Blobs because of the monkeypatched `Blob` incorrectly injects the script tag into the resulting SVG.

We've found that our users cannot view SVGs on our website while ExpressVPN is enabled. This is a big problem for our site which depends on viewing and manipulating SVGs.

cc @expressvpn-andre-l / @expressvpn-tom-l 

## Before / After

You can see an example of how SVGs were encoded before these changes [here](https://codepen.io/Taj-Pereira/pen/ZEZyQRy).
- The SVG is not properly rendered.

You can see an example of SVG rendering after these changes [here](https://codepen.io/Taj-Pereira/pen/PogjZaY).
- The SVG is rendered 😄 

Note: I quickly hacked together these changes. Please amend as you see fit!